### PR TITLE
Fix bug in MasterLockKeeper

### DIFF
--- a/scheduledtask-core/src/test/java/com/storebrand/scheduledtask/db/InMemoryMasterLockRepositoryTest.java
+++ b/scheduledtask-core/src/test/java/com/storebrand/scheduledtask/db/InMemoryMasterLockRepositoryTest.java
@@ -394,6 +394,8 @@ public class InMemoryMasterLockRepositoryTest {
      * First node releases the lock, and the second node then acquires it
      */
     @Test
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "We don't need to check values in the setup of the test")
     public void firstNodeReleasesLock_ok() {
         // :: Setup
         Instant initiallyAcquired = LocalDateTime.of(2021, 2, 28, 13, 20)
@@ -424,6 +426,8 @@ public class InMemoryMasterLockRepositoryTest {
     }
 
     @Test
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+            justification = "We don't need to check values in the setup of the test")
     public void secondNodeShouldNotBeAllowedToReleaseNode1Lock_fail() {
         // :: Setup
         Instant initiallyAcquired = LocalDateTime.of(2021, 2, 28, 13, 20)


### PR DESCRIPTION
The thread that keeps the master lock died because there was no catch all, and the exception was allowed to crash the thread. Added catch all to ensure the thread does not die.

Also fixed the check for if the master lock is present, by ensuring that we have updated the lock within the last 5 minutes.