### PR TITLE
log to standard logger, modalbox close fix and disable execute scheduler button

### DIFF
--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -702,6 +702,7 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus done(String msg) {
             _scheduledRunDto.setStatus(State.DONE, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log.info("[" + State.DONE + "] " + msg);
             log("[" + State.DONE + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
@@ -710,6 +711,7 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus failed(String msg) {
             _scheduledRunDto.setStatus(State.FAILED, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log.error("[" + State.FAILED + "] " + msg);
             log("[" + State.FAILED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
@@ -718,6 +720,7 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus failed(String msg, Throwable throwable) {
             _scheduledRunDto.setStatus(State.FAILED, Instant.now(_clock), msg, throwableToStackTraceString(throwable));
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log.error("[" + State.FAILED + "] " + msg);
             log("[" + State.FAILED + "] " + msg, throwable);
             return new ScheduleStatusValidResponse();
         }
@@ -726,6 +729,7 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus dispatched(String msg) {
             _scheduledRunDto.setStatus(State.DISPATCHED, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log.info("[" + State.DISPATCHED + "] " + msg);
             log("[" + State.DISPATCHED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -689,11 +689,13 @@ class ScheduledTaskRunner implements ScheduledTask {
 
         @Override
         public void log(String msg) {
+            log.info(msg);
             _scheduledTaskRepository.addLogEntry(_runId, LocalDateTime.now(_clock), msg);
         }
 
         @Override
         public void log(String msg, Throwable throwable) {
+            log.info(msg, throwable);
             _scheduledTaskRepository.addLogEntry(_runId, LocalDateTime.now(_clock), msg,
                     throwableToStackTraceString(throwable));
         }
@@ -702,7 +704,6 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus done(String msg) {
             _scheduledRunDto.setStatus(State.DONE, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
-            log.info("[" + State.DONE + "] " + msg);
             log("[" + State.DONE + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
@@ -711,7 +712,6 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus failed(String msg) {
             _scheduledRunDto.setStatus(State.FAILED, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
-            log.error("[" + State.FAILED + "] " + msg);
             log("[" + State.FAILED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
@@ -720,7 +720,6 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus failed(String msg, Throwable throwable) {
             _scheduledRunDto.setStatus(State.FAILED, Instant.now(_clock), msg, throwableToStackTraceString(throwable));
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
-            log.error("[" + State.FAILED + "] " + msg);
             log("[" + State.FAILED + "] " + msg, throwable);
             return new ScheduleStatusValidResponse();
         }
@@ -729,7 +728,6 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus dispatched(String msg) {
             _scheduledRunDto.setStatus(State.DISPATCHED, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
-            log.info("[" + State.DISPATCHED + "] " + msg);
             log("[" + State.DISPATCHED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -689,13 +689,13 @@ class ScheduledTaskRunner implements ScheduledTask {
 
         @Override
         public void log(String msg) {
-            log.info(msg);
+            log.info("ScheduledRunId [" + _runId + "]: " + msg);
             _scheduledTaskRepository.addLogEntry(_runId, LocalDateTime.now(_clock), msg);
         }
 
         @Override
         public void log(String msg, Throwable throwable) {
-            log.info(msg, throwable);
+            log.error("ScheduledRunId [" + _runId + "]: " + msg, throwable);
             _scheduledTaskRepository.addLogEntry(_runId, LocalDateTime.now(_clock), msg,
                     throwableToStackTraceString(throwable));
         }
@@ -712,7 +712,8 @@ class ScheduledTaskRunner implements ScheduledTask {
         public ScheduleStatus failed(String msg) {
             _scheduledRunDto.setStatus(State.FAILED, Instant.now(_clock), msg);
             _scheduledTaskRepository.setStatus(_scheduledRunDto);
-            log("[" + State.FAILED + "] " + msg);
+            log.error("ScheduledRunId [" + _runId + "]: " + msg);
+            _scheduledTaskRepository.addLogEntry(_runId, LocalDateTime.now(_clock), msg);
             return new ScheduleStatusValidResponse();
         }
 

--- a/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
+++ b/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
@@ -759,10 +759,10 @@ public class LocalHtmlInspectScheduler {
         }
 
         public String buttonDisabled() {
-            // Button should be disabled if the schedule is either:
-            // 1: Running
-            // 2: Not active
-            return running || !active ? "disabled" : "";
+            // Button should be disabled if the schedule is Not active.
+            // We cant disable the button when the schedule is set to in-active due to the inactive nodes has
+            // no status of current running state
+            return !active ? "disabled" : "";
         }
 
         public String getLastRunStarted() {

--- a/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
+++ b/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
@@ -105,8 +105,20 @@ public class LocalHtmlInspectScheduler {
                 // Then set the show modal for this one.
                 + "    modalBoxToShow.addClass(\"show-modal\");"
                 + "}); ");
-        // Listens for close mobalbox events (by click on the x inside the modalbox
+        // Listens for close mobalbox events (by click on the x inside the modalbox)
         out.write("$('.log-modal-content .log-modal-content-close').click(closeLogModalBox);");
+
+        // Listens click events outside the modalbox, this should close the modalbox.
+        out.write("$('.log-modal-box').click(function(e) {"
+                        // ?: Did we find any open modal boxes?
+                + "    if ($('.log-modal-box.show-modal').size() > 0) {"
+                           // -> Yes, we did. Is the click outside the modal box?"
+                + "        if (e.target.closest('.log-modal-content') == null) {"
+                + "                closeLogModalBox();"
+                + "            }"
+                + "      }"
+                + "    }"
+                + ");");
     }
 
     /**
@@ -421,7 +433,7 @@ public class LocalHtmlInspectScheduler {
                 + "            <div class=\"input-group\">"
                 + "                <input type=\"hidden\" name=\"executeScheduler.local\" class=\"form-control\" value=\"" + schedule.getSchedulerName() + "\">"
                 + "                <span class=\"input-group-btn\">"
-                + "        <button class=\"btn btn-primary\" type=\"submit\">Execute Scheduler</button>"
+                + "        <button class=\"btn btn-primary\" type=\"submit\" " + schedule.buttonDisabled() + ">Execute Scheduler</button>"
                 + "                 </span>"
                 + "            </div>"
                 + "        </form>"
@@ -744,6 +756,13 @@ public class LocalHtmlInspectScheduler {
 
         public String isActive() {
             return active ? "✅" : "❌";
+        }
+
+        public String buttonDisabled() {
+            // Button should be disabled if the schedule is either:
+            // 1: Running
+            // 2: Not active
+            return running || !active ? "disabled" : "";
         }
 
         public String getLastRunStarted() {


### PR DESCRIPTION
* If a schedule is running or it is marked as inactive the Execute scheduler button will be disabled. This closes #8 

* When context.log is used it will also output to the default logger in addition to the database. This closes #7 

* You can now close the modal box by clicking outside the modalbox in addition to the x icon.