### PR TITLE
Add support for NOOP result

### DIFF
--- a/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
+++ b/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
@@ -99,6 +99,14 @@ public @interface ScheduledTask {
     int deleteFailedRunsAfterDays() default 0;
 
     /**
+     * Define the number of days we should keep a record of noop runs for this schedule. If both this and
+     * {@link #deleteRunsAfterDays()} is used then both rules will be applied, and the lowest of the two will be used
+     * to determine when to delete failed runs.
+     * The default is to delete records after 7 days. Set to 0 to disable this rule.
+     */
+    int deleteNoopRunsAfterDays() default ScheduledTaskBuilder.DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS;
+
+    /**
      * Only keep this many runs. Older records will be deleted if there are more. This rule is disabled by default.
      */
     int keepMaxRuns() default 0;
@@ -116,4 +124,11 @@ public @interface ScheduledTask {
      * used to determine how many to keep.
      */
     int keepMaxFailedRuns() default 0;
+
+    /**
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 by
+     * default. If both this and {@link #keepMaxRuns()} is used then both will be applied, and the lowest number will be
+     * used to determine how many to keep.
+     */
+    int keepMaxNoopRuns() default ScheduledTaskBuilder.DEFAULT_KEEP_MAX_NOOP_RUNS;
 }

--- a/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTaskAnnotationUtils.java
+++ b/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTaskAnnotationUtils.java
@@ -104,9 +104,11 @@ public class ScheduledTaskAnnotationUtils {
                     .deleteRunsAfterDays(annotation.deleteRunsAfterDays())
                     .deleteSuccessfulRunsAfterDays(annotation.deleteSuccessfulRunsAfterDays())
                     .deleteFailedRunsAfterDays(annotation.deleteFailedRunsAfterDays())
+                    .deleteNoopRunsAfterDays(annotation.deleteNoopRunsAfterDays())
                     .keepMaxRuns(annotation.keepMaxRuns())
                     .keepMaxSuccessfulRuns(annotation.keepMaxSuccessfulRuns())
                     .keepMaxFailedRuns(annotation.keepMaxFailedRuns())
+                    .keepMaxNoopRuns(annotation.keepMaxNoopRuns())
                     .start();
         }
     }

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.Schedule;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunContext;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunnable;
+import com.storebrand.scheduledtask.ScheduledTaskRegistry.State;
 
 /**
  * Represents a running scheduled task.
@@ -218,9 +219,13 @@ public interface ScheduledTask {
 
         int getDeleteFailedRunsAfterDays();
 
+        int getDeleteNoopRunsAfterDays();
+
         int getKeepMaxFailedRuns();
 
         int getKeepMaxSuccessfulRuns();
+
+        int getKeepMaxNoopRuns();
 
         int getKeepMaxRuns();
 

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
@@ -33,6 +33,8 @@ public interface ScheduledTaskBuilder {
     Criticality DEFAULT_CRITICALITY = Criticality.IMPORTANT;
     Recovery DEFAULT_RECOVERY = Recovery.SELF_HEALING;
     int DEFAULT_DELETE_RUNS_AFTER_DAYS = 365;
+    int DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS = 7;
+    int DEFAULT_KEEP_MAX_NOOP_RUNS = 100;
 
     /**
      * Define the maximum minutes this task is expected to run.
@@ -94,6 +96,17 @@ public interface ScheduledTaskBuilder {
     ScheduledTaskBuilder deleteFailedRunsAfterDays(int days);
 
     /**
+     * Define the number of days we should keep a record of noop runs for this schedule. By default this is 1 week.
+     * If both this and {@link #deleteRunsAfterDays(int)} is used then both rules will be applied, and the
+     * lowest of the two will be used to determine when to delete failed runs.
+     *
+     * @param days
+     *         after this number of days we should delete records of noop runs.
+     * @return the initializer that builds the {@link ScheduledTask}.
+     */
+    ScheduledTaskBuilder deleteNoopRunsAfterDays(int days);
+
+    /**
      * Only keep this many runs. Older records will be deleted if there are more. This rule is disabled by default.
      *
      * @param maxRuns
@@ -124,6 +137,17 @@ public interface ScheduledTaskBuilder {
      */
     ScheduledTaskBuilder keepMaxFailedRuns(int maxFailedRuns);
 
+
+    /**
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 records
+     * by default. If both this and {@link #keepMaxRuns(int)} is used then both will be applied, and the lowest number
+     * will be used to determine how many to keep.
+     *
+     * @param maxNoopRuns
+     *         the maximum number of noop runs we should keep records of.
+     * @return the initializer that builds the {@link ScheduledTask}.
+     */
+    ScheduledTaskBuilder keepMaxNoopRuns(int maxNoopRuns);
 
     /**
      * Initializes and starts the scheduled task. It is important to call this, or the scheduled task will not be

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistry.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistry.java
@@ -120,6 +120,7 @@ public interface ScheduledTaskRegistry {
         STARTED,
         FAILED,
         DISPATCHED,
+        NOOP,
         DONE
     }
 
@@ -227,6 +228,14 @@ public interface ScheduledTaskRegistry {
          * {@link #done(String)} is not set.
          */
         ScheduleStatus dispatched(String msg);
+
+        /**
+         * Result indicating that the task did nothing.
+         * This can be used for ScheduledTasks that has a check element in addition to the cron expression
+         * to test if it should run. Noop entries have separate retention from DONE and FAILED. Also, they could be
+         * presented in a different manner in UI, as these are less important.
+         */
+        ScheduleStatus noop(String msg);
     }
 
     /**

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskConfig.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskConfig.java
@@ -93,21 +93,28 @@ public class ScheduledTaskConfig {
 
         private final int _keepMaxFailedRuns;
         private final int _keepMaxSuccessfulRuns;
+        private final int _keepMaxNoopRuns;
 
         private final int _keepMaxRuns;
 
         private final int _deleteFailedRunsAfterDays;
         private final int _deleteSuccessfulRunsAfterDays;
+        private final int _deleteNoopRunsAfterDays;
 
         private final int _deleteRunsAfterDays;
 
-        private StaticRetentionPolicy(int keepMaxSuccessfulRuns, int keepMaxFailedRuns, int keepMaxRuns, int deleteSuccessfulRunsAfterDays,
-                int deleteFailedRunsAfterDays, int deleteRunsAfterDays) {
+        private StaticRetentionPolicy(
+                int keepMaxSuccessfulRuns, int keepMaxFailedRuns, int keepMaxNoopRuns,
+                int keepMaxRuns,
+                int deleteSuccessfulRunsAfterDays, int deleteFailedRunsAfterDays, int deleteNoopRunsAfterDays,
+                int deleteRunsAfterDays) {
             _keepMaxFailedRuns = keepMaxFailedRuns;
             _keepMaxSuccessfulRuns = keepMaxSuccessfulRuns;
+            _keepMaxNoopRuns = keepMaxNoopRuns;
             _keepMaxRuns = keepMaxRuns;
             _deleteFailedRunsAfterDays = deleteFailedRunsAfterDays;
             _deleteSuccessfulRunsAfterDays = deleteSuccessfulRunsAfterDays;
+            _deleteNoopRunsAfterDays = deleteNoopRunsAfterDays;
             _deleteRunsAfterDays = deleteRunsAfterDays;
         }
 
@@ -126,6 +133,11 @@ public class ScheduledTaskConfig {
         }
 
         @Override
+        public int getKeepMaxNoopRuns() {
+            return _keepMaxNoopRuns;
+        }
+
+        @Override
         public int getKeepMaxRuns() {
             return _keepMaxRuns;
         }
@@ -141,25 +153,39 @@ public class ScheduledTaskConfig {
         }
 
         @Override
+        public int getDeleteNoopRunsAfterDays() {
+            return _deleteNoopRunsAfterDays;
+        }
+
+        @Override
         public int getDeleteRunsAfterDays() {
             return _deleteRunsAfterDays;
         }
 
         @Override
         public boolean isRetentionPolicyEnabled() {
-            return _deleteRunsAfterDays > 0 || _deleteFailedRunsAfterDays > 0 || _deleteSuccessfulRunsAfterDays > 0
-                    || _keepMaxRuns > 0 || _keepMaxFailedRuns > 0 || _keepMaxSuccessfulRuns > 0;
+            return _deleteRunsAfterDays > 0
+                    || _deleteFailedRunsAfterDays > 0
+                    || _deleteSuccessfulRunsAfterDays > 0
+                    || _deleteNoopRunsAfterDays > 0
+                    || _keepMaxRuns > 0
+                    || _keepMaxFailedRuns > 0
+                    || _keepMaxNoopRuns > 0
+                    || _keepMaxSuccessfulRuns > 0;
         }
 
         public static class Builder {
             private int _keepMaxSuccessfulRuns;
             private int _keepMaxFailedRuns;
+            private int _keepMaxNoopRuns = ScheduledTaskBuilder.DEFAULT_KEEP_MAX_NOOP_RUNS; // Default 100
 
             private int _keepMaxRuns;
 
             private int _deleteSuccessfulRunsAfterDays;
             private int _deleteFailedRunsAfterDays;
 
+            private int _deleteNoopRunsAfterDays
+                    = ScheduledTaskBuilder.DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS; // Default one week
             private int _deleteRunsAfterDays = ScheduledTaskBuilder.DEFAULT_DELETE_RUNS_AFTER_DAYS; // Default one year
 
             public Builder keepMaxSuccessfulRuns(int keepMaxSuccessfulRuns) {
@@ -169,6 +195,11 @@ public class ScheduledTaskConfig {
 
             public Builder keepMaxFailedRuns(int keepMaxFailedRuns) {
                 _keepMaxFailedRuns = keepMaxFailedRuns;
+                return this;
+            }
+
+            public Builder keepMaxNoopRuns(int keepMaxNoopRuns) {
+                _keepMaxNoopRuns = keepMaxNoopRuns;
                 return this;
             }
 
@@ -187,14 +218,21 @@ public class ScheduledTaskConfig {
                 return this;
             }
 
+            public Builder deleteNoopRunsAfterDays(int days) {
+                _deleteNoopRunsAfterDays = days;
+                return this;
+            }
+
             public Builder deleteRunsAfterDays(int days) {
                 _deleteRunsAfterDays = days;
                 return this;
             }
 
             public RetentionPolicy build() {
-                return new StaticRetentionPolicy(_keepMaxSuccessfulRuns, _keepMaxFailedRuns, _keepMaxRuns,
-                        _deleteSuccessfulRunsAfterDays, _deleteFailedRunsAfterDays, _deleteRunsAfterDays);
+                return new StaticRetentionPolicy(_keepMaxSuccessfulRuns, _keepMaxFailedRuns, _keepMaxNoopRuns,
+                        _keepMaxRuns,
+                        _deleteSuccessfulRunsAfterDays, _deleteFailedRunsAfterDays, _deleteNoopRunsAfterDays,
+                        _deleteRunsAfterDays);
             }
         }
     }

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistryImpl.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistryImpl.java
@@ -396,9 +396,11 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         private int _deleteRunsAfter = DEFAULT_DELETE_RUNS_AFTER_DAYS;
         private int _deleteSuccessfulRunsAfter;
         private int _deleteFailedRunsAfterDays;
+        private int _deleteNoopRunsAfterDays = DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS;
         private int _keepMaxRuns;
         private int _keepMaxSuccessfulRuns;
         private int _keepMaxFailedRuns;
+        private int _keepMaxNoopRuns = DEFAULT_KEEP_MAX_NOOP_RUNS;
 
         private ScheduledTaskRunnerBuilder(String scheduleName, String cronExpression,
                 ScheduleRunnable runnable) {
@@ -444,6 +446,12 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         }
 
         @Override
+        public ScheduledTaskBuilder deleteNoopRunsAfterDays(int days) {
+            _deleteNoopRunsAfterDays = days;
+            return this;
+        }
+
+        @Override
         public ScheduledTaskBuilder keepMaxRuns(int maxRuns) {
             _keepMaxRuns = maxRuns;
             return this;
@@ -458,6 +466,12 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         @Override
         public ScheduledTaskBuilder keepMaxFailedRuns(int maxFailedRuns) {
             _keepMaxFailedRuns = maxFailedRuns;
+            return this;
+        }
+
+        @Override
+        public ScheduledTaskBuilder keepMaxNoopRuns(int maxNoopRuns) {
+            _keepMaxNoopRuns = maxNoopRuns;
             return this;
         }
 
@@ -483,8 +497,10 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
                         .deleteRunsAfterDays(_deleteRunsAfter)
                         .deleteSuccessfulRunsAfterDays(_deleteSuccessfulRunsAfter)
                         .deleteFailedRunsAfterDays(_deleteFailedRunsAfterDays)
+                        .deleteNoopRunsAfterDays(_deleteNoopRunsAfterDays)
                         .keepMaxRuns(_keepMaxRuns)
                         .keepMaxSuccessfulRuns(_keepMaxSuccessfulRuns)
+                        .keepMaxNoopRuns(_keepMaxNoopRuns)
                         .keepMaxFailedRuns(_keepMaxFailedRuns).build();
 
                 ScheduledTaskConfig config = new ScheduledTaskConfig(_scheduleName, _cronExpression,

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -729,6 +729,14 @@ class ScheduledTaskRunner implements ScheduledTask {
             log("[" + State.DISPATCHED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
+
+        @Override
+        public ScheduleStatus noop(String msg) {
+            _scheduledRunDto.setStatus(State.NOOP, Instant.now(_clock), msg);
+            _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log("[" + State.NOOP + "] " + msg);
+            return new ScheduleStatusValidResponse();
+        }
     }
 
     /**

--- a/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
+++ b/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
@@ -164,6 +164,14 @@ class MockRunContext implements ScheduleRunContext {
         return createValidStatus();
     }
 
+
+    @Override
+    public ScheduleStatus noop(String msg) {
+        _state = State.NOOP;
+        _statusMessage = msg;
+        return createValidStatus();
+    }
+
     private void addLogEntry(String message, Throwable throwable) {
         synchronized (_logEntries) {
             LogEntry entry = new MockLogEntry(_logEntries.size() + 1, _id, message,


### PR DESCRIPTION
This allows to have a separate result from done, when nothing was done. This also affects the HTML introspector, that will collapse all NOOP runs to a single line, so as to not interfere with other normal runs.