### PR TITLE
Improve healthchecks

### DIFF
--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
@@ -75,6 +75,12 @@ public interface ScheduledTask {
     void runNow();
 
     /**
+     * Check if the schedule task thread is active. This should in theory always be true, but if the thread has been
+     * stopped by some external means it will return false.
+     */
+    boolean isThreadActive();
+
+    /**
      * Check if this schedule is currently set to active ie {@link #start()} (default on startup).
      *
      * @return - True: It is executing the supplied runnable. - False: It is currently set to skip executing the
@@ -97,6 +103,11 @@ public interface ScheduledTask {
      * schedule is taking longer than expected.
      */
     boolean isRunning();
+
+    /**
+     * Checks if this run has passed expected run time.
+     */
+    boolean hasPassedExpectedRunTime(Instant runStarted);
 
     /**
      * Checks if this run is taking longer time than it was expected to use during creation of the schedule.

--- a/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
+++ b/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
@@ -295,8 +295,7 @@ public class LocalHtmlInspectScheduler {
 
             // For the stats of the previous run we need to retrieve the lastRun for this schedule, so we can update
             // the monitor status.
-            ScheduledTask schedule = _scheduledTaskRegistry.getScheduledTask(scheduledTask.getName());
-            Optional<ScheduleRunContext> lastRun = schedule.getLastScheduleRun();
+            Optional<ScheduleRunContext> lastRun = scheduledTask.getLastScheduleRun();
             // ?: Did we have a last run?
             if (lastRun.isPresent()) {
                 scheduleDto.lastRunStatus = lastRun.get().getStatus();


### PR DESCRIPTION
* Added healthcheck for schedule task thread
<img width="1122" alt="thread-not-running" src="https://github.com/storebrand/scheduledtask/assets/37803050/b87a61ee-b86a-45b4-ba38-cf9643875bd0">

* Added healthcheck for schedule which has passed next run
![passed-next-run](https://github.com/storebrand/scheduledtask/assets/37803050/465e0cc7-71e5-414b-aaab-438bd25a03be)

* Added logging for master run sleep to verify that runner is alive
![elided-logging](https://github.com/storebrand/scheduledtask/assets/37803050/e38921ef-80d1-48c8-80cd-828a71e60cb8)
