### PR TITLE
Log to loggerfactory, support noop runs, healthcheck and monitor improvments

### DIFF
--- a/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
+++ b/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
@@ -126,9 +126,9 @@ public @interface ScheduledTask {
     int keepMaxFailedRuns() default 0;
 
     /**
-     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 by
-     * default. If both this and {@link #keepMaxRuns()} is used then both will be applied, and the lowest number will be
-     * used to determine how many to keep.
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 2160 by
+     * default (1 minute runs for 36 hours). If both this and {@link #keepMaxRuns()} is used then
+     * both will be applied, and the lowest number will be used to determine how many to keep.
      */
     int keepMaxNoopRuns() default ScheduledTaskBuilder.DEFAULT_KEEP_MAX_NOOP_RUNS;
 }

--- a/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
+++ b/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTask.java
@@ -99,6 +99,14 @@ public @interface ScheduledTask {
     int deleteFailedRunsAfterDays() default 0;
 
     /**
+     * Define the number of days we should keep a record of noop runs for this schedule. If both this and
+     * {@link #deleteRunsAfterDays()} is used then both rules will be applied, and the lowest of the two will be used
+     * to determine when to delete failed runs.
+     * The default is to delete records after 7 days. Set to 0 to disable this rule.
+     */
+    int deleteNoopRunsAfterDays() default ScheduledTaskBuilder.DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS;
+
+    /**
      * Only keep this many runs. Older records will be deleted if there are more. This rule is disabled by default.
      */
     int keepMaxRuns() default 0;
@@ -116,4 +124,11 @@ public @interface ScheduledTask {
      * used to determine how many to keep.
      */
     int keepMaxFailedRuns() default 0;
+
+    /**
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 by
+     * default. If both this and {@link #keepMaxRuns()} is used then both will be applied, and the lowest number will be
+     * used to determine how many to keep.
+     */
+    int keepMaxNoopRuns() default ScheduledTaskBuilder.DEFAULT_KEEP_MAX_NOOP_RUNS;
 }

--- a/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTaskAnnotationUtils.java
+++ b/scheduledtask-annotation/src/main/java/com/storebrand/scheduledtask/annotation/ScheduledTaskAnnotationUtils.java
@@ -104,9 +104,11 @@ public class ScheduledTaskAnnotationUtils {
                     .deleteRunsAfterDays(annotation.deleteRunsAfterDays())
                     .deleteSuccessfulRunsAfterDays(annotation.deleteSuccessfulRunsAfterDays())
                     .deleteFailedRunsAfterDays(annotation.deleteFailedRunsAfterDays())
+                    .deleteNoopRunsAfterDays(annotation.deleteNoopRunsAfterDays())
                     .keepMaxRuns(annotation.keepMaxRuns())
                     .keepMaxSuccessfulRuns(annotation.keepMaxSuccessfulRuns())
                     .keepMaxFailedRuns(annotation.keepMaxFailedRuns())
+                    .keepMaxNoopRuns(annotation.keepMaxNoopRuns())
                     .start();
         }
     }

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.Schedule;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunContext;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunnable;
+import com.storebrand.scheduledtask.ScheduledTaskRegistry.State;
 
 /**
  * Represents a running scheduled task.
@@ -229,9 +230,13 @@ public interface ScheduledTask {
 
         int getDeleteFailedRunsAfterDays();
 
+        int getDeleteNoopRunsAfterDays();
+
         int getKeepMaxFailedRuns();
 
         int getKeepMaxSuccessfulRuns();
+
+        int getKeepMaxNoopRuns();
 
         int getKeepMaxRuns();
 

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.Schedule;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunContext;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunnable;
-import com.storebrand.scheduledtask.ScheduledTaskRegistry.State;
 
 /**
  * Represents a running scheduled task.
@@ -76,10 +75,10 @@ public interface ScheduledTask {
     void runNow();
 
     /**
-     * Check if the schedule task thread is active. This should in theory always be true, but if the thread has been
+     * Check if the schedule task thread is alive. This should in theory always be true, but if the thread has been
      * stopped by some external means it will return false.
      */
-    boolean isThreadActive();
+    boolean isThreadAlive();
 
     /**
      * Check if this schedule is currently set to active ie {@link #start()} (default on startup).

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
@@ -33,8 +33,8 @@ public interface ScheduledTaskBuilder {
     Criticality DEFAULT_CRITICALITY = Criticality.IMPORTANT;
     Recovery DEFAULT_RECOVERY = Recovery.SELF_HEALING;
     int DEFAULT_DELETE_RUNS_AFTER_DAYS = 365;
-    int DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS = 7;
-    int DEFAULT_KEEP_MAX_NOOP_RUNS = 1440; // 1 minute runs for 24 hours
+    int DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS = 14;
+    int DEFAULT_KEEP_MAX_NOOP_RUNS = 2160; // 1 minute runs for 36 hours
 
     /**
      * Define the maximum minutes this task is expected to run.
@@ -139,9 +139,9 @@ public interface ScheduledTaskBuilder {
 
 
     /**
-     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 records
-     * by default. If both this and {@link #keepMaxRuns(int)} is used then both will be applied, and the lowest number
-     * will be used to determine how many to keep.
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 2160 records
+     * by default (1 minute runs for 36 hours). If both this and {@link #keepMaxRuns(int)} is used then both will be
+     * applied, and the lowest number will be used to determine how many to keep.
      *
      * @param maxNoopRuns
      *         the maximum number of noop runs we should keep records of.

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
@@ -33,6 +33,8 @@ public interface ScheduledTaskBuilder {
     Criticality DEFAULT_CRITICALITY = Criticality.IMPORTANT;
     Recovery DEFAULT_RECOVERY = Recovery.SELF_HEALING;
     int DEFAULT_DELETE_RUNS_AFTER_DAYS = 365;
+    int DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS = 7;
+    int DEFAULT_KEEP_MAX_NOOP_RUNS = 100;
 
     /**
      * Define the maximum minutes this task is expected to run.
@@ -94,6 +96,17 @@ public interface ScheduledTaskBuilder {
     ScheduledTaskBuilder deleteFailedRunsAfterDays(int days);
 
     /**
+     * Define the number of days we should keep a record of noop runs for this schedule. By default this is 1 week.
+     * If both this and {@link #deleteRunsAfterDays(int)} is used then both rules will be applied, and the
+     * lowest of the two will be used to determine when to delete failed runs.
+     *
+     * @param days
+     *         after this number of days we should delete records of noop runs.
+     * @return the initializer that builds the {@link ScheduledTask}.
+     */
+    ScheduledTaskBuilder deleteNoopRunsAfterDays(int days);
+
+    /**
      * Only keep this many runs. Older records will be deleted if there are more. This rule is disabled by default.
      *
      * @param maxRuns
@@ -124,6 +137,17 @@ public interface ScheduledTaskBuilder {
      */
     ScheduledTaskBuilder keepMaxFailedRuns(int maxFailedRuns);
 
+
+    /**
+     * Only keep this many noop runs. Older records will be deleted if there are more. This rule is set to 100 records
+     * by default. If both this and {@link #keepMaxRuns(int)} is used then both will be applied, and the lowest number
+     * will be used to determine how many to keep.
+     *
+     * @param maxNoopRuns
+     *         the maximum number of noop runs we should keep records of.
+     * @return the initializer that builds the {@link ScheduledTask}.
+     */
+    ScheduledTaskBuilder keepMaxNoopRuns(int maxNoopRuns);
 
     /**
      * Initializes and starts the scheduled task. It is important to call this, or the scheduled task will not be

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskBuilder.java
@@ -34,7 +34,7 @@ public interface ScheduledTaskBuilder {
     Recovery DEFAULT_RECOVERY = Recovery.SELF_HEALING;
     int DEFAULT_DELETE_RUNS_AFTER_DAYS = 365;
     int DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS = 7;
-    int DEFAULT_KEEP_MAX_NOOP_RUNS = 100;
+    int DEFAULT_KEEP_MAX_NOOP_RUNS = 1440; // 1 minute runs for 24 hours
 
     /**
      * Define the maximum minutes this task is expected to run.

--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistry.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistry.java
@@ -120,6 +120,7 @@ public interface ScheduledTaskRegistry {
         STARTED,
         FAILED,
         DISPATCHED,
+        NOOP,
         DONE
     }
 
@@ -227,6 +228,14 @@ public interface ScheduledTaskRegistry {
          * {@link #done(String)} is not set.
          */
         ScheduleStatus dispatched(String msg);
+
+        /**
+         * Result indicating that the task did nothing.
+         * This can be used for ScheduledTasks that has a check element in addition to the cron expression
+         * to test if it should run. Noop entries have separate retention from DONE and FAILED. Also, they could be
+         * presented in a different manner in UI, as these are less important.
+         */
+        ScheduleStatus noop(String msg);
     }
 
     /**

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskConfig.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskConfig.java
@@ -93,21 +93,28 @@ public class ScheduledTaskConfig {
 
         private final int _keepMaxFailedRuns;
         private final int _keepMaxSuccessfulRuns;
+        private final int _keepMaxNoopRuns;
 
         private final int _keepMaxRuns;
 
         private final int _deleteFailedRunsAfterDays;
         private final int _deleteSuccessfulRunsAfterDays;
+        private final int _deleteNoopRunsAfterDays;
 
         private final int _deleteRunsAfterDays;
 
-        private StaticRetentionPolicy(int keepMaxSuccessfulRuns, int keepMaxFailedRuns, int keepMaxRuns, int deleteSuccessfulRunsAfterDays,
-                int deleteFailedRunsAfterDays, int deleteRunsAfterDays) {
+        private StaticRetentionPolicy(
+                int keepMaxSuccessfulRuns, int keepMaxFailedRuns, int keepMaxNoopRuns,
+                int keepMaxRuns,
+                int deleteSuccessfulRunsAfterDays, int deleteFailedRunsAfterDays, int deleteNoopRunsAfterDays,
+                int deleteRunsAfterDays) {
             _keepMaxFailedRuns = keepMaxFailedRuns;
             _keepMaxSuccessfulRuns = keepMaxSuccessfulRuns;
+            _keepMaxNoopRuns = keepMaxNoopRuns;
             _keepMaxRuns = keepMaxRuns;
             _deleteFailedRunsAfterDays = deleteFailedRunsAfterDays;
             _deleteSuccessfulRunsAfterDays = deleteSuccessfulRunsAfterDays;
+            _deleteNoopRunsAfterDays = deleteNoopRunsAfterDays;
             _deleteRunsAfterDays = deleteRunsAfterDays;
         }
 
@@ -126,6 +133,11 @@ public class ScheduledTaskConfig {
         }
 
         @Override
+        public int getKeepMaxNoopRuns() {
+            return _keepMaxNoopRuns;
+        }
+
+        @Override
         public int getKeepMaxRuns() {
             return _keepMaxRuns;
         }
@@ -141,25 +153,39 @@ public class ScheduledTaskConfig {
         }
 
         @Override
+        public int getDeleteNoopRunsAfterDays() {
+            return _deleteNoopRunsAfterDays;
+        }
+
+        @Override
         public int getDeleteRunsAfterDays() {
             return _deleteRunsAfterDays;
         }
 
         @Override
         public boolean isRetentionPolicyEnabled() {
-            return _deleteRunsAfterDays > 0 || _deleteFailedRunsAfterDays > 0 || _deleteSuccessfulRunsAfterDays > 0
-                    || _keepMaxRuns > 0 || _keepMaxFailedRuns > 0 || _keepMaxSuccessfulRuns > 0;
+            return _deleteRunsAfterDays > 0
+                    || _deleteFailedRunsAfterDays > 0
+                    || _deleteSuccessfulRunsAfterDays > 0
+                    || _deleteNoopRunsAfterDays > 0
+                    || _keepMaxRuns > 0
+                    || _keepMaxFailedRuns > 0
+                    || _keepMaxNoopRuns > 0
+                    || _keepMaxSuccessfulRuns > 0;
         }
 
         public static class Builder {
             private int _keepMaxSuccessfulRuns;
             private int _keepMaxFailedRuns;
+            private int _keepMaxNoopRuns = ScheduledTaskBuilder.DEFAULT_KEEP_MAX_NOOP_RUNS; // Default 100
 
             private int _keepMaxRuns;
 
             private int _deleteSuccessfulRunsAfterDays;
             private int _deleteFailedRunsAfterDays;
 
+            private int _deleteNoopRunsAfterDays
+                    = ScheduledTaskBuilder.DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS; // Default one week
             private int _deleteRunsAfterDays = ScheduledTaskBuilder.DEFAULT_DELETE_RUNS_AFTER_DAYS; // Default one year
 
             public Builder keepMaxSuccessfulRuns(int keepMaxSuccessfulRuns) {
@@ -169,6 +195,11 @@ public class ScheduledTaskConfig {
 
             public Builder keepMaxFailedRuns(int keepMaxFailedRuns) {
                 _keepMaxFailedRuns = keepMaxFailedRuns;
+                return this;
+            }
+
+            public Builder keepMaxNoopRuns(int keepMaxNoopRuns) {
+                _keepMaxNoopRuns = keepMaxNoopRuns;
                 return this;
             }
 
@@ -187,14 +218,21 @@ public class ScheduledTaskConfig {
                 return this;
             }
 
+            public Builder deleteNoopRunsAfterDays(int days) {
+                _deleteNoopRunsAfterDays = days;
+                return this;
+            }
+
             public Builder deleteRunsAfterDays(int days) {
                 _deleteRunsAfterDays = days;
                 return this;
             }
 
             public RetentionPolicy build() {
-                return new StaticRetentionPolicy(_keepMaxSuccessfulRuns, _keepMaxFailedRuns, _keepMaxRuns,
-                        _deleteSuccessfulRunsAfterDays, _deleteFailedRunsAfterDays, _deleteRunsAfterDays);
+                return new StaticRetentionPolicy(_keepMaxSuccessfulRuns, _keepMaxFailedRuns, _keepMaxNoopRuns,
+                        _keepMaxRuns,
+                        _deleteSuccessfulRunsAfterDays, _deleteFailedRunsAfterDays, _deleteNoopRunsAfterDays,
+                        _deleteRunsAfterDays);
             }
         }
     }

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistryImpl.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRegistryImpl.java
@@ -396,9 +396,11 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         private int _deleteRunsAfter = DEFAULT_DELETE_RUNS_AFTER_DAYS;
         private int _deleteSuccessfulRunsAfter;
         private int _deleteFailedRunsAfterDays;
+        private int _deleteNoopRunsAfterDays = DEFAULT_DELETE_NOOP_RUNS_AFTER_DAYS;
         private int _keepMaxRuns;
         private int _keepMaxSuccessfulRuns;
         private int _keepMaxFailedRuns;
+        private int _keepMaxNoopRuns = DEFAULT_KEEP_MAX_NOOP_RUNS;
 
         private ScheduledTaskRunnerBuilder(String scheduleName, String cronExpression,
                 ScheduleRunnable runnable) {
@@ -444,6 +446,12 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         }
 
         @Override
+        public ScheduledTaskBuilder deleteNoopRunsAfterDays(int days) {
+            _deleteNoopRunsAfterDays = days;
+            return this;
+        }
+
+        @Override
         public ScheduledTaskBuilder keepMaxRuns(int maxRuns) {
             _keepMaxRuns = maxRuns;
             return this;
@@ -458,6 +466,12 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
         @Override
         public ScheduledTaskBuilder keepMaxFailedRuns(int maxFailedRuns) {
             _keepMaxFailedRuns = maxFailedRuns;
+            return this;
+        }
+
+        @Override
+        public ScheduledTaskBuilder keepMaxNoopRuns(int maxNoopRuns) {
+            _keepMaxNoopRuns = maxNoopRuns;
             return this;
         }
 
@@ -483,8 +497,10 @@ public class ScheduledTaskRegistryImpl implements ScheduledTaskRegistry {
                         .deleteRunsAfterDays(_deleteRunsAfter)
                         .deleteSuccessfulRunsAfterDays(_deleteSuccessfulRunsAfter)
                         .deleteFailedRunsAfterDays(_deleteFailedRunsAfterDays)
+                        .deleteNoopRunsAfterDays(_deleteNoopRunsAfterDays)
                         .keepMaxRuns(_keepMaxRuns)
                         .keepMaxSuccessfulRuns(_keepMaxSuccessfulRuns)
+                        .keepMaxNoopRuns(_keepMaxNoopRuns)
                         .keepMaxFailedRuns(_keepMaxFailedRuns).build();
 
                 ScheduledTaskConfig config = new ScheduledTaskConfig(_scheduleName, _cronExpression,

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -800,6 +800,14 @@ class ScheduledTaskRunner implements ScheduledTask {
             log("[" + State.DISPATCHED + "] " + msg);
             return new ScheduleStatusValidResponse();
         }
+
+        @Override
+        public ScheduleStatus noop(String msg) {
+            _scheduledRunDto.setStatus(State.NOOP, Instant.now(_clock), msg);
+            _scheduledTaskRepository.setStatus(_scheduledRunDto);
+            log("[" + State.NOOP + "] " + msg);
+            return new ScheduleStatusValidResponse();
+        }
     }
 
     /**

--- a/scheduledtask-db-sql/src/main/java/com/storebrand/scheduledtask/db/sql/ScheduledTaskSqlRepository.java
+++ b/scheduledtask-db-sql/src/main/java/com/storebrand/scheduledtask/db/sql/ScheduledTaskSqlRepository.java
@@ -611,7 +611,7 @@ public class ScheduledTaskSqlRepository implements ScheduledTaskRepository {
                 // -> Yes, then should only keep this many
 
                 Optional<LocalDateTime> deleteOlder = findDeleteOlderForKeepMax(sqlConnection, scheduleName,
-                        retentionPolicy.getKeepMaxFailedRuns(), State.NOOP);
+                        retentionPolicy.getKeepMaxNoopRuns(), State.NOOP);
 
                 if (deleteOlder.isPresent()) {
                     deletedRecords += executeDelete(sqlConnection, scheduleName, deleteOlder.get(), State.NOOP);

--- a/scheduledtask-healthcheck/src/main/java/com/storebrand/scheduledtask/healthcheck/ScheduledTaskHealthCheck.java
+++ b/scheduledtask-healthcheck/src/main/java/com/storebrand/scheduledtask/healthcheck/ScheduledTaskHealthCheck.java
@@ -155,7 +155,7 @@ public class ScheduledTaskHealthCheck implements ScheduledTaskListener {
                 Map<String, Schedule> allSchedulesFromDb = _scheduledTaskRegistry.getSchedulesFromRepository();
                 TableBuilder tableBuilder = new TableBuilder(
                         "Schedule name",
-                        "Thread running",
+                        "Thread alive",
                         "Active",
                         "Default cron",
                         "Running",

--- a/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
+++ b/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
@@ -524,9 +524,24 @@ public class LocalHtmlInspectScheduler {
         }
 
         // Get the historic runs for this schedule:
-        List<MonitorHistoricRunDto> scheduleRuns = schedule.getAllScheduleRunsBetween(fromDate, toDate).stream()
-                .map(MonitorHistoricRunDto::fromContext)
-                .collect(toList());
+        List<MonitorHistoricRunDto> scheduleRuns = new ArrayList<>();
+        for (ScheduleRunContext scheduleRunContext : schedule.getAllScheduleRunsBetween(fromDate, toDate)) {
+            // Get the previous run, if any
+            MonitorHistoricRunDto prev = scheduleRuns.isEmpty() ? null : scheduleRuns.get(scheduleRuns.size() - 1);
+            MonitorHistoricRunDto monitorHistoricRunDto =
+                    MonitorHistoricRunDto.fromContext(prev, scheduleRunContext);
+
+            // ?: Is this not a NOOP run or is it the first run?
+            if (monitorHistoricRunDto.status != State.NOOP || prev == null) {
+                // Yes -> then add it to the list
+                scheduleRuns.add(monitorHistoricRunDto);
+            }
+            else {
+                // No - then replace the previous run with this one. This causes us to collapse all subsequent NOOP
+                //      runs to a single run.
+                scheduleRuns.set(scheduleRuns.size() - 1, monitorHistoricRunDto);
+            }
+        }
 
         // We got a schedule name, check to see if we found it.
         out.write("<h2>Run logs for schedule: " + scheduleName + "</h2>");
@@ -633,11 +648,24 @@ public class LocalHtmlInspectScheduler {
 
     public void renderScheduleRunsRow(Writer out, MonitorHistoricRunDto runDto,
             LocalDateTime fromDate, LocalDateTime toDate) throws IOException {
+        // We collapse all noop runs to the latest one, so we should render the noop count if we have any.
+        String noopCount;
+        switch (runDto.getNoopCount()) {
+            case 0:
+                noopCount = "";
+                break;
+            case 1:
+                noopCount = " (1 time)";
+                break;
+            default:
+                noopCount = " (" + runDto.getNoopCount() + " times)";
+                break;
+        }
         out.write("<tr>"
                 + "    <td>" + runDto.getRunId() + "</td>"
                 + "    <td>" + runDto.getScheduleName() + "</td>"
                 + "    <td>" + runDto.getHostname() + "</td>"
-                + "    <td>" + runDto.getStatus() + "</td>"
+                + "    <td>" + runDto.getStatus() + noopCount + "</td>"
                 + "    <td>" + runDto.getStatusMsg() + "</td>"
                 + "    <td>"
                 + "        <div class=\"error-content log-modal-header\">"
@@ -913,29 +941,44 @@ public class LocalHtmlInspectScheduler {
         private final String scheduleName;
         private final String hostname;
         private final State status;
+        private final int noopCount;
         private final String statusMsg;
         private final String statusStackTrace;
         private final LocalDateTime runStart;
         private final LocalDateTime statusTime;
         private List<MonitorHistoricRunLogEntryDto> logEntries = new ArrayList<>();
 
-        public MonitorHistoricRunDto(long runId, String scheduleName, String hostname, State status, String statusMsg,
-                String statusStackTrace, LocalDateTime runStart, LocalDateTime statusTime) {
+        private MonitorHistoricRunDto(
+                long runId,
+                String scheduleName,
+                String hostname,
+                State status,
+                int noopCount,
+                String statusMsg,
+                String statusStackTrace,
+                LocalDateTime runStart,
+                LocalDateTime statusTime) {
             this.runId = runId;
             this.scheduleName = scheduleName;
             this.hostname = hostname;
             this.status = status;
+            this.noopCount = noopCount;
             this.statusMsg = statusMsg;
             this.statusStackTrace = statusStackTrace;
             this.runStart = runStart;
             this.statusTime = statusTime;
         }
 
-        public static MonitorHistoricRunDto fromContext(ScheduleRunContext context) {
+        public static MonitorHistoricRunDto fromContext(MonitorHistoricRunDto prev, ScheduleRunContext context) {
+            int noopCount = 0;
+            if (context.getStatus() == State.NOOP && prev != null) {
+                noopCount = prev.noopCount + 1;
+            }
             return new MonitorHistoricRunDto(context.getRunId(),
                     context.getScheduledName(),
                     context.getHostname(),
                     context.getStatus(),
+                    noopCount,
                     context.getStatusMsg(),
                     context.getStatusStackTrace(),
                     context.getRunStarted(),
@@ -956,6 +999,10 @@ public class LocalHtmlInspectScheduler {
 
         public State getStatus() {
             return status;
+        }
+
+        public int getNoopCount() {
+            return noopCount;
         }
 
         public String getStatusMsg() {

--- a/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
+++ b/scheduledtask-localinspect/src/main/java/com/storebrand/scheduledtask/localinspect/LocalHtmlInspectScheduler.java
@@ -34,6 +34,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+    import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -459,7 +460,10 @@ public class LocalHtmlInspectScheduler {
         Map<String, Schedule> allSchedulesFromDb = _scheduledTaskRegistry.getSchedulesFromRepository();
         // Get all the schedules from memory
         List<MonitorScheduleDto> bindingsDtoMap = new ArrayList<>();
-        for (ScheduledTask scheduledTask : _scheduledTaskRegistry.getScheduledTasks().values()) {
+        List<ScheduledTask> scheduledTasksByName = _scheduledTaskRegistry.getScheduledTasks().values().stream()
+                .sorted(Comparator.comparing(ScheduledTask::getName, String.CASE_INSENSITIVE_ORDER))
+                .collect(toList());
+        for (ScheduledTask scheduledTask : scheduledTasksByName) {
             MonitorScheduleDto scheduleDto = new MonitorScheduleDto(scheduledTask);
             // Since the in memory can be missing some of the previous runs we need to supplement the in-memory values
             // with data from the tables stb_schedule and stb_schedule_run

--- a/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
+++ b/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
@@ -165,6 +165,14 @@ class MockRunContext implements ScheduleRunContext {
         return createValidStatus();
     }
 
+
+    @Override
+    public ScheduleStatus noop(String msg) {
+        _state = State.NOOP;
+        _statusMessage = msg;
+        return createValidStatus();
+    }
+
     private void addLogEntry(String message, Throwable throwable) {
         synchronized (_logEntries) {
             LogEntry entry = new MockLogEntry(_logEntries.size() + 1, _id, message,

--- a/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
+++ b/scheduledtask-testing/src/main/java/com/storebrand/scheduledtask/testing/MockRunContext.java
@@ -170,6 +170,7 @@ class MockRunContext implements ScheduleRunContext {
     public ScheduleStatus noop(String msg) {
         _state = State.NOOP;
         _statusMessage = msg;
+        log("[" + State.DISPATCHED + "] " + msg);
         return createValidStatus();
     }
 


### PR DESCRIPTION
* Context.log/failed/done/dispached will now also output to the default logger. Resolves #7 
* All runs will append the schedule name to the MDC with the key "scheduledTask".
* Added support for NOOP runs. When seeing these runs in the monitorm and 
  if there is several consecutive runs in a row these will 
  be aggregated together and showing a count on how many where aggregated.
* NOOP runs has deleteNoopRunsAfterDays and keepMaxNoopRuns that can be set.
  They have defaults of deleteNoopRunsAfterDays = 7 and keepMaxNoopRuns=1440.
* Added checkbox to allow to inspect all NOOP runs, this only works if the 
  new integration is using the html function to render the HTML GUI.
* NOOP runs are shown with a color grey and a grey background.
* DONE runs are shown with a green color.
* FAILED runs are shown with red.
* The loglines are now shown under the row and by clicking this row they will appear.
* StackTraces are no longer shown in a modal box but rendered directly when the logs are shown.
* StackTraces will show the indents.
* BUG FIX: The HealthCheck "passed next run" where calculated from a memory variable on the given master.
  If there was a master switch this meant that this variable would be null or worse be days old and thus 
  giving a wrong or not working HealthCheck.
* HealthCheck changed from using true false to ✓/- when all is ok, and a describing word in caps when there 
  is an issue. This to assist in reading the healthCheck table.
* BUG FIX: In rare occations you could get a negative sleep number resulting in exception thrown. This would 
  cause the schedule to wait a bit before trying again and autorecover.
* If runOnce() is called inside a schedule run it will cause the schedule to retrigger immediately.
* Listing of schedules is now sorted by name. Resolves #9 
* HealthCheck table column "Thread running" is renamed to "Thread alive".
