### PR TITLE
SQLException caused schedule to be marked as running

### DIFF
--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -278,13 +278,15 @@ class ScheduledTaskRunner implements ScheduledTask {
                 _scheduledTaskRepository.executeRetentionPolicy(getName(), _config.getRetentionPolicy());
             }
             catch (Throwable t) {
+                // Since we got an exception, we are not currently running the schedule:
+                _isRunning = false;
+
                 // ?: Check again for runThreads - as this will happen in shutdown
                 if (!_runFlag) {
                     // -> Yes, we're stopping.
                     log.info("Thread for Task '" + getName() + " got '" + t.getClass()
                             .getSimpleName()
                             + "' from the run-loop, but runThread-flag was false, so we're evidently exiting.");
-                    _isRunning = false;
                     break;
                 }
 
@@ -530,6 +532,12 @@ class ScheduledTaskRunner implements ScheduledTask {
         // Is this schedule started at all?
         if (_currentRunStarted == null) {
             // ->NO, so it is not overdue
+            return Optional.empty();
+        }
+
+        // ?: Is this currentRunStarted before _lastRunCompleted, if so, it means we are not currently running
+        if (_currentRunStarted.isBefore(_lastRunCompleted)) {
+            // -> Yes, we are not currently running, so we are not overdue
             return Optional.empty();
         }
 


### PR DESCRIPTION
* If an SQLException occured right after the thread wake up it would be caputured by the main try cach and go back to sleep. However since the isRunning flag is set to true right after the thread wakes up and it where not set to false in this try cach block it would be set to status running even when the schedule slept.

* Checking if the currentRunStarted is before lastRunComplete. If it is then we are not currently running and the overdue flag is set to false.

Closes #28