### PR TITLE
CronExpressions requires 0 seconds

### DIFF
--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/SpringCronUtils.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/SpringCronUtils.java
@@ -567,6 +567,14 @@ class SpringCronUtils {
                 throw new IllegalArgumentException(String.format(
                         "Cron expression must consist of 6 fields (found %d in \"%s\")", fields.length, expression));
             }
+
+            // We only accept 0 as input for the seconds' field.
+            String conSeconds = fields[0];
+            if (!"0".equals(conSeconds)) {
+                throw new IllegalArgumentException(String.format("Cron expression must have seconds field set to 0 "
+                        + "(found \"%s\" seconds in \"%s\")", conSeconds, expression));
+            }
+
             try {
                 CronField seconds = CronField.parseSeconds(fields[0]);
                 CronField minutes = CronField.parseMinutes(fields[1]);


### PR DESCRIPTION
* Added requirement to allways use 0 as the second part for the ConExpression. If anything else than 0 is set here the it will prevent the service from starting and outputting a stackTrace informing an invalid CronExpression where used.


This is a breaking change for all services that have set anything else than 0 seconds on a schedule.