### PR TITLE
Inspection page fetches all logEntries by rundIs in one go.

### DIFF
--- a/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
+++ b/scheduledtask-api/src/main/java/com/storebrand/scheduledtask/ScheduledTask.java
@@ -19,8 +19,10 @@ package com.storebrand.scheduledtask;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import com.storebrand.scheduledtask.ScheduledTaskRegistry.LogEntry;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.Schedule;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunContext;
 import com.storebrand.scheduledtask.ScheduledTaskRegistry.ScheduleRunnable;
@@ -97,6 +99,11 @@ public interface ScheduledTask {
      * Retrieve all schedule runs between two dates. This filters by the start time of the schedule runs.
      */
     List<ScheduleRunContext> getAllScheduleRunsBetween(LocalDateTime from, LocalDateTime to);
+
+    /**
+     * Retrieves all schedule run ids between two dates with all the logs.
+     */
+    Map<Long, List<LogEntry>> getLogEntriesByRunId(LocalDateTime from, LocalDateTime to);
 
     /**
      * Check if this current schedule is currently running. Can be used with {@link #isOverdue()} to check if this

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/ScheduledTaskRunner.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -483,6 +484,11 @@ class ScheduledTaskRunner implements ScheduledTask {
                         _scheduledTaskRepository, _clock))
                 .collect(toList());
 
+    }
+
+    @Override
+    public Map<Long, List<LogEntry>> getLogEntriesByRunId(LocalDateTime from, LocalDateTime to) {
+        return _scheduledTaskRepository.getLogEntriesByRunId(getName(), from, to);
     }
 
     /**

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/db/InMemoryScheduledTaskRepository.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/db/InMemoryScheduledTaskRepository.java
@@ -193,6 +193,14 @@ public class InMemoryScheduledTaskRepository implements ScheduledTaskRepository 
     }
 
     @Override
+    public Map<Long, List<LogEntry>> getLogEntriesByRunId(String scheduleName, LocalDateTime from, LocalDateTime to) {
+        long logId = _logIdGenerator.incrementAndGet();
+        List<LogEntry> logs = _logs.compute(logId,
+                (id, existingLogs) -> existingLogs != null ? existingLogs : new ArrayList<>());
+        return Map.of(logId, logs);
+    }
+
+    @Override
     public void addLogEntry(long runId, LocalDateTime logTime, String message, String stackTrace) {
         _logs.compute(runId, (id, existingLogs) -> {
             List<LogEntry> logs = existingLogs != null ? existingLogs : new ArrayList<>();

--- a/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/db/ScheduledTaskRepository.java
+++ b/scheduledtask-core/src/main/java/com/storebrand/scheduledtask/db/ScheduledTaskRepository.java
@@ -177,6 +177,17 @@ public interface ScheduledTaskRepository {
      */
     List<ScheduledRunDto> getScheduleRunsBetween(String scheduleName, LocalDateTime from, LocalDateTime to);
 
+
+    /**
+     * Get all {@link ScheduledRunDto} between a given timespan including the logs for each run.
+     *
+     * @param from
+     *         - from time and including
+     * @param to
+     *         - to and including
+     */
+    Map<Long,List<LogEntry>> getLogEntriesByRunId(String scheduleName, LocalDateTime from, LocalDateTime to);
+
     /**
      * Add a log entry to a specified scheduled task run, by using the scheduled runs instanceId.
      * @param runId


### PR DESCRIPTION
* Improving loading of schedule runs with that are running quite often. Previously each runId queried the database one time 
pr runId.

* Added support for having newline \n char in the message field.

resolves #31